### PR TITLE
v1 Rework: Configuration format, container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,80 @@ This downloads and compiles `devsh` and places it into `$GOPATH/bin`.
 
 ## How to use
 
-
 ### Configure your project
 
-Place a `.devsh` file into the root folder of your project.
+Place a `.devsh` file into the root folder of your project to configure the
+development container. It is a YAML file; when present it must specify at least
+an image:
 
-It should contain at least one line:
 ```yaml
-image: dev-go # docker image name to use for your development container
+image: dev-go # docker image to use for the development container
 ```
+
+All other keys are optional:
+
+```yaml
+image: dev-go                        # docker image for the dev container (required)
+name: my-project                     # project name (default: current directory name)
+shell_cmd: /bin/bash                 # shell to start inside the container (default: /bin/bash)
+container_host: my-project           # hostname for the container (default: project name)
+container_dir: /my-project           # path where the project is mounted inside the container
+container_name: my-project           # name of the container (default: <dir_name>-<hash>)
+ports:                               # container ports exposed on the host
+  - 8080:8080
+volumes:                             # additional volumes to mount inside the container
+  - /home/alex/data:/data
+network: my-network                  # docker network for the container
+dns: 8.8.8.8                         # explicit DNS server for the container
+```
+
+### Global configuration
+
+A global configuration file can be placed at `~/.config/devsh`. It uses the same
+format as the project `.devsh` file and provides defaults for all projects. The
+location of the global config file can be overridden with the `DEVSH_CONFIG`
+environment variable:
+
+```
+DEVSH_CONFIG=~/my-devsh-config devsh
+```
+
+Configuration values are combined from the following sources, listed from the
+lowest priority to the highest:
+
+1. Built-in defaults
+2. Global configuration file (`~/.config/devsh` or `$DEVSH_CONFIG`)
+3. Project configuration file (`.devsh` in the current folder)
+4. Command-line flags
+
+For each parameter, the value from the highest-priority source that provides it
+takes precedence; values from lower-priority sources are inherited when a
+higher-priority source does not set the parameter.
+
+### Minimal configuration (without a `.devsh` file)
+
+A `.devsh` file is not required. You can run `devsh` in any folder as long as
+the docker image is provided through the global configuration or the `--image`
+flag. For example, set a default image once for all projects:
+
+```
+echo "image: dev-go" > ~/.config/devsh
+```
+
+then run `devsh` in any folder:
+
+```
+devsh
+```
+
+or pass the image on the command line:
+
+```
+devsh --image dev-go
+```
+
+All other parameters fall back to their built-in defaults (e.g. the container
+name is derived from the current directory name).
 
 ### Starting a shell in the development container
 
@@ -47,4 +112,44 @@ Run in your project root folder:
 
 ```
 devsh
+```
+
+This starts the development container (if it is not running yet) and opens a
+shell into it.
+
+### Commands
+
+| Command | Description |
+|---|---|
+| `devsh` | Start the container (if needed) and open a shell (default action) |
+| `devsh start` | Start the development container |
+| `devsh open` | Open a shell in the running container |
+| `devsh status` | Show the status of the container |
+| `devsh stop` | Stop and remove the container |
+| `devsh config` | Show the effective configuration for the current project |
+
+### Command-line flags
+
+Every configuration parameter can also be set via a command-line flag. Flags
+have the highest priority and override values from the config files:
+
+| Flag | Description |
+|---|---|
+| `-i, --image` | Docker image for the dev container |
+| `-n, --name` | Name of the project |
+| `-s, --shell-cmd` | Shell to start inside the dev container |
+| `--container-host` | Hostname for the dev container |
+| `--container-dir` | Path inside the container where the project is mounted |
+| `--container-name` | Human-readable name for the dev container |
+| `-p, --ports` | Ports of the container exposed on the host |
+| `-V, --volumes` | Additional volumes to be mounted inside the dev container |
+| `--network` | Docker network for the dev container |
+| `--dns` | Explicit DNS server to use for the dev container |
+
+Use `-v`/`--verbose` to print the docker commands devsh runs.
+
+Example:
+
+```
+devsh --image dev-go --network my-network -p 8080:8080
 ```

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -8,46 +8,39 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
 
 const (
-	globalConfigFilename string = "~/.devsh/config"
-	configFilename       string = ".devsh"
+	configFilename string = ".devsh"
 )
 
-type GlobalConfigValues struct {
-	Image               string   `yaml:"image,omitempty"`
-	ShellCmd            string   `yaml:"shell_cmd,omitempty"`
-	DevContainerPorts   []string `yaml:"dev_container_ports,omitempty"`
-	DevContainerVolumes []string `yaml:"dev_container_volumes,omitempty"`
-	DevContainerNetwork string   `yaml:"dev_container_network,omitempty"`
-	DevContainerDNS     string   `yaml:"dev_container_dns,omitempty"`
-}
-
-var defaultGlobalConfigValues = GlobalConfigValues{
-	Image:               "",
-	ShellCmd:            "/bin/bash",
-	DevContainerPorts:   nil,
-	DevContainerVolumes: nil,
-	DevContainerNetwork: "",
-	DevContainerDNS:     "",
-}
-
-// Project config values replace global config values if set
+// ConfigValues holds every configurable parameter of devsh. The same set of
+// values can be provided by any of the three configuration sources: the global
+// config file, the project .devsh file, and command-line flags.
 type ConfigValues struct {
-	Image               string   `yaml:"image,omitempty"`
-	Name                string   `yaml:"name,omitempty"`
-	ShellCmd            string   `yaml:"shell_cmd,omitempty"`
-	DevContainerHost    string   `yaml:"dev_container_host,omitempty"`
-	DevContainerDir     string   `yaml:"dev_container_dir,omitempty"`
-	DevContainerName    string   `yaml:"dev_container_name,omitempty"`
-	DevContainerPorts   []string `yaml:"dev_container_ports,omitempty"`
-	DevContainerVolumes []string `yaml:"dev_container_volumes,omitempty"`
-	DevContainerNetwork string   `yaml:"dev_container_network,omitempty"`
-	DevContainerDNS     string   `yaml:"dev_container_dns,omitempty"`
+	Image         string   `yaml:"image,omitempty"`
+	Name          string   `yaml:"name,omitempty"`
+	ShellCmd      string   `yaml:"shell_cmd,omitempty"`
+	ContainerHost string   `yaml:"container_host,omitempty"`
+	ContainerDir  string   `yaml:"container_dir,omitempty"`
+	ContainerName string   `yaml:"container_name,omitempty"`
+	Ports         []string `yaml:"ports,omitempty"`
+	Volumes       []string `yaml:"volumes,omitempty"`
+	Network       string   `yaml:"network,omitempty"`
+	DNS           string   `yaml:"dns,omitempty"`
+}
+
+// defaultConfigValues returns the built-in defaults. These have the lowest
+// priority and are only used when a value is not provided by any of the three
+// configuration sources.
+func defaultConfigValues() ConfigValues {
+	return ConfigValues{
+		ShellCmd: "/bin/bash",
+	}
 }
 
 // configCmd represents the config command
@@ -56,33 +49,37 @@ var configCmd = &cobra.Command{
 	Short: "Show the current project configuration",
 	Long: `Show the configuration of the project in the current folder.
 
-The configuration of the project is combined from the global devsh configuration
-found in (TBD) and the local configuration file placed in the project root directory.
+The configuration is combined from the following sources, listed from the
+lowest priority to the highest:
 
-The local project configuration file should be named '.devsh' and placed in the root
-directory of the project.
+  1. Built-in defaults
+  2. Global configuration file (default: ~/.config/devsh, overridable via
+     the DEVSH_CONFIG environment variable)
+  3. Project configuration file (.devsh in the current folder)
+  4. Command-line flags
 
-.devsh file is a YAML file with the following format (all keys are optional):
+For every parameter, the value from the highest-priority source that provides
+it takes precedence; values from lower-priority sources are inherited when a
+higher-priority source does not set the parameter.
+
+The .devsh file is a YAML file with the following format (all keys are optional):
   image: # docker image to be used for dev container
   name: # name of the project, if omitted the directory name is used
-  TBD_devenv: # name of the docker compose environment, to attach to
   shell_cmd: # shell to start inside the dev container, e.g. /bin/bash
-  dev_container_host: # name of the host for the dev container
-  dev_container_dir: # path inside the dev container where the project is going to be mounted
-  dev_container_name: # human-readable name for the dev container in docker
-  dev_container_ports: # ports of the container exposed on host
-  dev_container_volumes: # additional volumes to be mounted inside the dev container
-  dev_container_network: # docker network for the dev container
-  dev_container_dns: # explicit DNS server to use for the dev container
-
-  TBD
+  container_host: # name of the host for the dev container
+  container_dir: # path inside the dev container where the project is going to be mounted
+  container_name: # human-readable name for the dev container in docker
+  ports: # ports of the container exposed on host
+  volumes: # additional volumes to be mounted inside the dev container
+  network: # docker network for the dev container
+  dns: # explicit DNS server to use for the dev container
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		cfg := configLoad()
+		cfg := configLoad(cmd)
 
 		configYaml, err := yaml.Marshal(cfg)
 		if err != nil {
-			log.Fatalf("ERROR: Failed to serialize config: ", err)
+			log.Fatalf("ERROR: Failed to serialize config: %s", err)
 		}
 
 		fmt.Printf("---\n%s\n", string(configYaml))
@@ -90,52 +87,161 @@ directory of the project.
 }
 
 // Loads and returns a combined config for the project in the current folder.
-func configLoad() ConfigValues {
-	globalConfigValues := configLoadGlobal()
-	configValues := configLoadLocal()
+//
+// Values are merged from four layers, each overriding the previous one:
+//  1. built-in defaults
+//  2. global configuration file
+//  3. project configuration file (.devsh)
+//  4. command-line flags
+//
+// Finally, values that are still empty are filled with dynamically constructed
+// conventional defaults derived from the project directory.
+func configLoad(cmd *cobra.Command) ConfigValues {
+	cfg := defaultConfigValues()
 
-	// fill empty values with defaults from the global configuration
-	if configValues.Image == "" {
-		configValues.Image = globalConfigValues.Image
-	}
-	if configValues.ShellCmd == "" {
-		configValues.ShellCmd = globalConfigValues.ShellCmd
-	}
-	if len(configValues.DevContainerPorts) == 0 {
-		configValues.DevContainerPorts = globalConfigValues.DevContainerPorts
-	}
-	if len(configValues.DevContainerVolumes) == 0 {
-		configValues.DevContainerVolumes = globalConfigValues.DevContainerVolumes
-	}
-	if configValues.DevContainerNetwork == "" {
-		configValues.DevContainerNetwork = globalConfigValues.DevContainerNetwork
-	}
-	if configValues.DevContainerDNS == "" {
-		configValues.DevContainerDNS = globalConfigValues.DevContainerDNS
+	cfg = mergeConfig(cfg, configLoadGlobal())
+	cfg = mergeConfig(cfg, configLoadLocal())
+	cfg = mergeConfig(cfg, configLoadFlags(cmd))
+
+	// fill values that are still empty with dynamically constructed defaults
+	if cfg.Name == "" {
+		cfg.Name = configDefaultProjectName()
 	}
 
-	// fill values that are still empty with dynamically constructed conventional defaults
-	if configValues.Name == "" {
-		configValues.Name = configDefaultProjectName()
+	if cfg.ContainerHost == "" {
+		cfg.ContainerHost = configDefaultContainerHost(cfg)
+	}
+	if cfg.ContainerDir == "" {
+		cfg.ContainerDir = configDefaultContainerDir(cfg)
+	}
+	if cfg.ContainerName == "" {
+		cfg.ContainerName = configDefaultContainerName(cfg)
+	}
+	if cfg.Network == "" {
+		cfg.Network = configDefaultNetwork(cfg)
+	}
+	if cfg.DNS == "" {
+		cfg.DNS = configDefaultDNS(cfg)
 	}
 
-	if configValues.DevContainerHost == "" {
-		configValues.DevContainerHost = configDefaultDevContainerHost(configValues)
+	return cfg
+}
+
+// mergeConfig returns base with every field overridden by the corresponding
+// non-empty field from override. Empty fields in override are ignored so that
+// lower-priority values are inherited. Slice fields are replaced (not
+// concatenated) when override provides any values.
+func mergeConfig(base, override ConfigValues) ConfigValues {
+	if override.Image != "" {
+		base.Image = override.Image
 	}
-	if configValues.DevContainerDir == "" {
-		configValues.DevContainerDir = configDefaultDevContainerDir(configValues)
+	if override.Name != "" {
+		base.Name = override.Name
 	}
-	if configValues.DevContainerName == "" {
-		configValues.DevContainerName = configDefaultDevContainerName(configValues)
+	if override.ShellCmd != "" {
+		base.ShellCmd = override.ShellCmd
 	}
-	if configValues.DevContainerNetwork == "" {
-		configValues.DevContainerNetwork = configDefaultDevContainerNetwork(configValues)
+	if override.ContainerHost != "" {
+		base.ContainerHost = override.ContainerHost
 	}
-	if configValues.DevContainerDNS == "" {
-		configValues.DevContainerDNS = configDefaultDevContainerDNS(configValues)
+	if override.ContainerDir != "" {
+		base.ContainerDir = override.ContainerDir
+	}
+	if override.ContainerName != "" {
+		base.ContainerName = override.ContainerName
+	}
+	if len(override.Ports) > 0 {
+		base.Ports = override.Ports
+	}
+	if len(override.Volumes) > 0 {
+		base.Volumes = override.Volumes
+	}
+	if override.Network != "" {
+		base.Network = override.Network
+	}
+	if override.DNS != "" {
+		base.DNS = override.DNS
+	}
+	return base
+}
+
+// configLoadFlags collects values provided via command-line flags. Only flags
+// that were explicitly set on the command line are taken into account, so that
+// unset flags do not clobber values coming from the config files.
+func configLoadFlags(cmd *cobra.Command) ConfigValues {
+	var cfg ConfigValues
+	if cmd == nil {
+		return cfg
 	}
 
-	return configValues
+	flags := cmd.Flags()
+
+	if flags.Changed("image") {
+		cfg.Image, _ = flags.GetString("image")
+	}
+	if flags.Changed("name") {
+		cfg.Name, _ = flags.GetString("name")
+	}
+	if flags.Changed("shell-cmd") {
+		cfg.ShellCmd, _ = flags.GetString("shell-cmd")
+	}
+	if flags.Changed("container-host") {
+		cfg.ContainerHost, _ = flags.GetString("container-host")
+	}
+	if flags.Changed("container-dir") {
+		cfg.ContainerDir, _ = flags.GetString("container-dir")
+	}
+	if flags.Changed("container-name") {
+		cfg.ContainerName, _ = flags.GetString("container-name")
+	}
+	if flags.Changed("ports") {
+		cfg.Ports, _ = flags.GetStringSlice("ports")
+	}
+	if flags.Changed("volumes") {
+		cfg.Volumes, _ = flags.GetStringSlice("volumes")
+	}
+	if flags.Changed("network") {
+		cfg.Network, _ = flags.GetString("network")
+	}
+	if flags.Changed("dns") {
+		cfg.DNS, _ = flags.GetString("dns")
+	}
+
+	return cfg
+}
+
+// configGlobalPath returns the path to the global configuration file. The
+// location can be overridden with the DEVSH_CONFIG environment variable; it
+// defaults to ~/.config/devsh. A leading '~' is expanded to the user's home
+// directory.
+func configGlobalPath() string {
+	if p := os.Getenv("DEVSH_CONFIG"); p != "" {
+		return expandTilde(p)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatalf("ERROR: Failed to determine home directory: %s", err)
+	}
+	return filepath.Join(home, ".config", "devsh")
+}
+
+// expandTilde replaces a leading '~' with the user's home directory.
+func expandTilde(p string) string {
+	if p == "~" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return p
+		}
+		return home
+	}
+	if strings.HasPrefix(p, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return p
+		}
+		return filepath.Join(home, p[2:])
+	}
+	return p
 }
 
 func configLoadLocal() ConfigValues {
@@ -145,57 +251,47 @@ func configLoadLocal() ConfigValues {
 		log.Printf("WARN: Config file is not found: %s\n", configFilename)
 		return ConfigValues{}
 	}
+	if err != nil {
+		log.Fatalf("ERROR: Failed to stat config file %s: %s", configFilename, err)
+	}
 
 	configFile, err := os.ReadFile(configFilename)
 	if err != nil {
-
-		log.Fatalf("ERROR: Failed to open config file: %s", err)
-		panic(err)
+		log.Fatalf("ERROR: Failed to read config file %s: %s", configFilename, err)
 	}
 
 	var configValues ConfigValues
-	yaml.Unmarshal(configFile, &configValues)
+	if err := yaml.Unmarshal(configFile, &configValues); err != nil {
+		log.Fatalf("ERROR: Failed to parse config file %s: %s", configFilename, err)
+	}
 
 	return configValues
 }
 
-func configLoadGlobal() GlobalConfigValues {
-	// If the config file does not exist, return an empty/default configuration
-	_, err := os.Stat(globalConfigFilename)
+func configLoadGlobal() ConfigValues {
+	path := configGlobalPath()
+
+	// If the config file does not exist, return an empty configuration; a
+	// global config file is optional.
+	_, err := os.Stat(path)
 	if errors.Is(err, os.ErrNotExist) {
-		return defaultGlobalConfigValues
+		return ConfigValues{}
 	}
-
-	configFile, err := os.ReadFile(globalConfigFilename)
 	if err != nil {
-
-		log.Fatalf("ERROR: Failed to open config file: %s", err)
+		log.Fatalf("ERROR: Failed to stat global config file %s: %s", path, err)
 	}
 
-	var globalConfigValues GlobalConfigValues
-	yaml.Unmarshal(configFile, &globalConfigValues)
-
-	// fill empty values with defaults from the global configuration
-	if globalConfigValues.Image == "" {
-		globalConfigValues.Image = defaultGlobalConfigValues.Image
-	}
-	if globalConfigValues.ShellCmd == "" {
-		globalConfigValues.ShellCmd = defaultGlobalConfigValues.ShellCmd
-	}
-	if len(globalConfigValues.DevContainerPorts) == 0 {
-		globalConfigValues.DevContainerPorts = defaultGlobalConfigValues.DevContainerPorts
-	}
-	if len(globalConfigValues.DevContainerVolumes) == 0 {
-		globalConfigValues.DevContainerVolumes = defaultGlobalConfigValues.DevContainerVolumes
-	}
-	if globalConfigValues.DevContainerNetwork == "" {
-		globalConfigValues.DevContainerNetwork = defaultGlobalConfigValues.DevContainerNetwork
-	}
-	if globalConfigValues.DevContainerDNS == "" {
-		globalConfigValues.DevContainerDNS = defaultGlobalConfigValues.DevContainerDNS
+	configFile, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatalf("ERROR: Failed to read global config file %s: %s", path, err)
 	}
 
-	return globalConfigValues
+	var configValues ConfigValues
+	if err := yaml.Unmarshal(configFile, &configValues); err != nil {
+		log.Fatalf("ERROR: Failed to parse global config file %s: %s", path, err)
+	}
+
+	return configValues
 }
 
 // Returns the project folder (i.e. current folder) on the host
@@ -214,27 +310,27 @@ func configDefaultProjectName() string {
 }
 
 // Returns the default hostname for the dev container
-func configDefaultDevContainerHost(configValues ConfigValues) string {
+func configDefaultContainerHost(configValues ConfigValues) string {
 	return configValues.Name
 }
 
 // Returns the default path where the project is mounted inside the dev container
-func configDefaultDevContainerDir(configValues ConfigValues) string {
+func configDefaultContainerDir(configValues ConfigValues) string {
 	return "/" + configValues.Name
 }
 
 // Returns the default name for the dev container
-func configDefaultDevContainerName(configValues ConfigValues) string {
+func configDefaultContainerName(configValues ConfigValues) string {
 	return configValues.Name
 }
 
 // Returns the default network for the dev container
-func configDefaultDevContainerNetwork(_configValues ConfigValues) string {
+func configDefaultNetwork(_configValues ConfigValues) string {
 	return ""
 }
 
 // Returns the default DNS for the dev container
-func configDefaultDevContainerDNS(_configValues ConfigValues) string {
+func configDefaultDNS(_configValues ConfigValues) string {
 	return ""
 }
 
@@ -243,7 +339,7 @@ func configDefaultDevContainerDNS(_configValues ConfigValues) string {
 //
 //	configDevContainerPrimaryVolume() // "/home/alex/Projects/devsh:/devsh"
 func configDevContainerPrimaryVolume(configValues ConfigValues) string {
-	return configProjectDir() + ":" + configValues.DevContainerDir
+	return configProjectDir() + ":" + configValues.ContainerDir
 }
 
 func init() {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -247,10 +247,10 @@ func expandTilde(p string) string {
 }
 
 func configLoadLocal() ConfigValues {
-	// If the config file does not exist, return an empty configuration
+	// A project config file is optional; return an empty configuration when it
+	// is not present (e.g. when running with minimal configuration).
 	_, err := os.Stat(configFilename)
 	if errors.Is(err, os.ErrNotExist) {
-		log.Printf("WARN: Config file is not found: %s\n", configFilename)
 		return ConfigValues{}
 	}
 	if err != nil {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -3,6 +3,8 @@
 package cmd
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log"
@@ -319,9 +321,19 @@ func configDefaultContainerDir(configValues ConfigValues) string {
 	return "/" + configValues.Name
 }
 
-// Returns the default name for the dev container
+// Returns the default name for the dev container. The name is composed of the
+// project (directory) name and a short suffix derived from the full path to the
+// project directory, e.g. "devsh-a1b2". The suffix disambiguates containers
+// for projects that share the same directory name.
 func configDefaultContainerName(configValues ConfigValues) string {
-	return configValues.Name
+	return configValues.Name + "-" + configProjectPathHash()
+}
+
+// configProjectPathHash returns the first 4 hex characters of the SHA-256 hash
+// of the full path to the current project directory.
+func configProjectPathHash() string {
+	h := sha256.Sum256([]byte(configProjectDir()))
+	return hex.EncodeToString(h[:2])
 }
 
 // Returns the default network for the dev container

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -14,7 +14,7 @@ var openCmd = &cobra.Command{
 
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		cfg := configLoad()
+		cfg := configLoad(cmd)
 		openShell(cfg)
 		statusDisplay(cfg)
 	},
@@ -24,7 +24,7 @@ func openShell(cfg ConfigValues) {
 	opts := []string{
 		"-ti",
 	}
-	shellCmd := dockerConstructCmd("exec", opts, cfg.DevContainerName, cfg.ShellCmd)
+	shellCmd := dockerConstructCmd("exec", opts, cfg.ContainerName, cfg.ShellCmd)
 	dockerRunInteractive(shellCmd)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,7 +33,7 @@ Or:
 		cfg := startContainerConfig(cmd)
 
 		// start the dev container if it is not started yet
-		if !(dockerIsContainerPresent(cfg.DevContainerName) && dockerIsContainerRunning(cfg.DevContainerName)) {
+		if !(dockerIsContainerPresent(cfg.ContainerName) && dockerIsContainerRunning(cfg.ContainerName)) {
 			dockerCmd := startDockerCmd(cfg)
 			dockerRunCmd(dockerCmd)
 		}
@@ -61,10 +61,19 @@ func init() {
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.devsh.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&globalFlagVerbose, "verbose", "v", false, "Produce verbose output")
 
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	// rootCmd.Flags().BoolVarP(&globalFlagVerbose, "verbose", "v", false, "Produce verbose output")
-	rootCmd.Flags().StringP("image", "i", "", "Use this docker image for the dev container")
+	// Configuration flags mirror the configurable parameters and have the
+	// highest priority, overriding values from the global and project config
+	// files. They are persistent so they apply to every subcommand.
+	rootCmd.PersistentFlags().StringP("image", "i", "", "Docker image for the dev container")
+	rootCmd.PersistentFlags().String("name", "", "Name of the project")
+	rootCmd.PersistentFlags().String("shell-cmd", "", "Shell to start inside the dev container (e.g. /bin/bash)")
+	rootCmd.PersistentFlags().String("container-host", "", "Hostname for the dev container")
+	rootCmd.PersistentFlags().String("container-dir", "", "Path inside the dev container where the project is mounted")
+	rootCmd.PersistentFlags().String("container-name", "", "Human-readable name for the dev container")
+	rootCmd.PersistentFlags().StringSlice("ports", nil, "Ports of the container exposed on the host")
+	rootCmd.PersistentFlags().StringSlice("volumes", nil, "Additional volumes to be mounted inside the dev container")
+	rootCmd.PersistentFlags().String("network", "", "Docker network for the dev container")
+	rootCmd.PersistentFlags().String("dns", "", "Explicit DNS server to use for the dev container")
 
 	rootCmd.SetVersionTemplate(VERSION_TEMPLATE)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,13 +65,13 @@ func init() {
 	// highest priority, overriding values from the global and project config
 	// files. They are persistent so they apply to every subcommand.
 	rootCmd.PersistentFlags().StringP("image", "i", "", "Docker image for the dev container")
-	rootCmd.PersistentFlags().String("name", "", "Name of the project")
-	rootCmd.PersistentFlags().String("shell-cmd", "", "Shell to start inside the dev container (e.g. /bin/bash)")
+	rootCmd.PersistentFlags().StringP("name", "n", "", "Name of the project")
+	rootCmd.PersistentFlags().StringP("shell-cmd", "s", "", "Shell to start inside the dev container (e.g. /bin/bash)")
 	rootCmd.PersistentFlags().String("container-host", "", "Hostname for the dev container")
 	rootCmd.PersistentFlags().String("container-dir", "", "Path inside the dev container where the project is mounted")
 	rootCmd.PersistentFlags().String("container-name", "", "Human-readable name for the dev container")
-	rootCmd.PersistentFlags().StringSlice("ports", nil, "Ports of the container exposed on the host")
-	rootCmd.PersistentFlags().StringSlice("volumes", nil, "Additional volumes to be mounted inside the dev container")
+	rootCmd.PersistentFlags().StringSliceP("ports", "p", nil, "Ports of the container exposed on the host")
+	rootCmd.PersistentFlags().StringSliceP("volumes", "V", nil, "Additional volumes to be mounted inside the dev container")
 	rootCmd.PersistentFlags().String("network", "", "Docker network for the dev container")
 	rootCmd.PersistentFlags().String("dns", "", "Explicit DNS server to use for the dev container")
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -48,7 +48,7 @@ func startContainerConfig(cmd *cobra.Command) ConfigValues {
 // Constructs the docker command from the dev container configuration
 func startDockerCmd(cfg ConfigValues) string {
 	opts := []string{
-		"--name " + cfg.Name,
+		"--name " + cfg.ContainerName,
 		"--hostname " + cfg.ContainerHost,
 		"--workdir " + cfg.ContainerDir,
 		"--detach",

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -18,7 +18,7 @@ var startCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := startContainerConfig(cmd)
 
-		if !dockerIsContainerPresent(cfg.DevContainerName) {
+		if !dockerIsContainerPresent(cfg.ContainerName) {
 			dockerCmd := startDockerCmd(cfg)
 			dockerRunCmd(dockerCmd)
 		}
@@ -27,28 +27,15 @@ var startCmd = &cobra.Command{
 	},
 }
 
-func startImageFlag(cmd *cobra.Command) string {
-	image, err := cmd.Flags().GetString("image")
-	if err != nil {
-		log.Fatalf("ERROR: Failed to fetch flag: ", err)
-	}
-	return image
-}
-
-// Returns the configuration constructed for the  dev container, combined from all the sources and validated
+// Returns the configuration constructed for the dev container, combined from
+// all the sources and validated.
 func startContainerConfig(cmd *cobra.Command) ConfigValues {
-	cfg := configLoad()
-
-	// process flags set for "start" command
-	image := startImageFlag(cmd)
-	if image != "" {
-		cfg.Image = image
-	}
+	cfg := configLoad(cmd)
 
 	// construct container volumes configuration
 	primaryVolume := configDevContainerPrimaryVolume(cfg)
-	cfg.DevContainerVolumes =
-		append([]string{primaryVolume}, cfg.DevContainerVolumes...)
+	cfg.Volumes =
+		append([]string{primaryVolume}, cfg.Volumes...)
 
 	// validate mandatory config values
 	if cfg.Image == "" {
@@ -62,20 +49,20 @@ func startContainerConfig(cmd *cobra.Command) ConfigValues {
 func startDockerCmd(cfg ConfigValues) string {
 	opts := []string{
 		"--name " + cfg.Name,
-		"--hostname " + cfg.DevContainerHost,
-		"--workdir " + cfg.DevContainerDir,
+		"--hostname " + cfg.ContainerHost,
+		"--workdir " + cfg.ContainerDir,
 		"--detach",
 	}
-	if cfg.DevContainerNetwork != "" {
-		opts = append(opts, "--network "+cfg.DevContainerNetwork)
+	if cfg.Network != "" {
+		opts = append(opts, "--network "+cfg.Network)
 	}
-	if cfg.DevContainerDNS != "" {
-		opts = append(opts, "--dns "+cfg.DevContainerDNS)
+	if cfg.DNS != "" {
+		opts = append(opts, "--dns "+cfg.DNS)
 	}
-	for _, ports := range cfg.DevContainerPorts {
+	for _, ports := range cfg.Ports {
 		opts = append(opts, "--publish "+ports)
 	}
-	for _, volume := range cfg.DevContainerVolumes {
+	for _, volume := range cfg.Volumes {
 		opts = append(opts, "--volume "+volume)
 	}
 
@@ -94,5 +81,4 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// startCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	startCmd.Flags().StringP("image", "i", "", "Use this docker image for the dev container")
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -39,7 +39,7 @@ func startContainerConfig(cmd *cobra.Command) ConfigValues {
 
 	// validate mandatory config values
 	if cfg.Image == "" {
-		log.Fatal("ERROR: Docker image for dev container is not specified, consider specifying it in a .devsh file")
+		log.Fatal("ERROR: Docker image for the dev container is not specified. Set it in the global config (~/.config/devsh), a .devsh file, or via the --image flag.")
 	}
 
 	return cfg

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -15,13 +15,13 @@ var statusCmd = &cobra.Command{
 	Long: `Shows status of the development container for the current project.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		cfg := configLoad()
+		cfg := configLoad(cmd)
 		statusDisplay(cfg)
 	},
 }
 
 func statusDisplay(cfg ConfigValues) {
-	containerName := cfg.DevContainerName
+	containerName := cfg.ContainerName
 	if dockerIsContainerPresent(containerName) {
 		if dockerIsContainerRunning(containerName) {
 			fmt.Printf("* Dev container %s is running (%s)\n", containerName, dockerContainerIdShort(containerName))

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -14,12 +14,12 @@ var stopCmd = &cobra.Command{
 
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		cfg := configLoad()
+		cfg := configLoad(cmd)
 
-		if dockerIsContainerPresent(cfg.DevContainerName) {
-			stopCmd := dockerConstructCmd("stop", nil, cfg.DevContainerName)
+		if dockerIsContainerPresent(cfg.ContainerName) {
+			stopCmd := dockerConstructCmd("stop", nil, cfg.ContainerName)
 			dockerRunCmd(stopCmd)
-			rmCmd := dockerConstructCmd("rm", nil, cfg.DevContainerName)
+			rmCmd := dockerConstructCmd("rm", nil, cfg.ContainerName)
 			dockerRunCmd(rmCmd)
 		}
 


### PR DESCRIPTION
* Configuration file format change
* Global configuration file location (~/.config/devsh)
* All configurable paramters can be also set via CLI flags
* Default container name is now `<NAME>-<SUFFIX>` where NAME is the project name, SUFFIX is the hash of the full path

